### PR TITLE
Programmatically request access to Reminder permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Reminders
 
-This is a simply Flutter plugin to provider, read, write, edit and delete access to Apple Reminders on ios and MacOS.
+This is a simple Flutter plugin to provider, read, write, edit and delete access to Apple Reminders on ios and MacOS.
 
 ## API
 
 When the `reminders` class is instantiated it requests permission to access the users reminders. If permission has not yet been given a popup will appear asking for permission. Success or failure can be determined:
+
+`Future<bool> requestPermission()`
+This will prompt a system alert dialog with the text you provided from 'NSRemindersUsageDescription'. Returns true if user accepted prompt (or has already accepted), or false (or if it has already been declined previously).
 
 `Future<bool> hasAccess()`
 
@@ -32,7 +35,7 @@ Future<String?> deleteReminder(String id) async`
 Add the following key/value pair to your Info.plist
 >
 >    `<key>NSRemindersUsageDescription</key>`
-> 
+>
 >    `<string>INSERT_REASON_HERE</string>`
 
 
@@ -43,7 +46,7 @@ Add the following to `macos/Runner/DebugProfile.entitlements` and 'macos/Runner/
 >
 >   `<key>com.apple.security.personal-information.calendars</key>`
 >   `<true/>`
->	
+>
 
 ### Android, Web, Windows & Linux integration
 

--- a/common/Reminders.swift
+++ b/common/Reminders.swift
@@ -14,16 +14,16 @@ class Reminders {
         return nil
     }
 
-    func requestPermission(_ completion: @escaping(Bool) -> ()) {
-        eventStore.requestAccess(to: EKEntityType.reminder) { (granted: Bool, error: Error?) -> Void in
-            if granted {
-                self.hasAccess = true
-                completion(true)
-            } else {
-                self.hasAccess = false
-                completion(false)
-            }
+    func requestPermission() -> Bool {
+        var granted = false
+        let semaphore = DispatchSemaphore(value: 0)
+        eventStore.requestAccess(to: EKEntityType.reminder) { (success, error) in
+            granted = success
+            semaphore.signal()
         }
+        semaphore.wait()
+        hasAccess = granted
+        return granted
     }
 
     func getAllLists() -> String? {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,6 +16,9 @@ class _ExampleAppState extends State<ExampleApp> {
 
   @override
   Widget build(BuildContext context) {
+    //request permission to access Reminders
+    reminders.requestPermission();
+
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       home: Scaffold(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,49 +5,56 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.1"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -59,7 +66,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -67,48 +75,62 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   reminders:
     dependency: "direct main"
     description:
@@ -125,51 +147,58 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.18.2 <3.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=3.0.0-0 <4.0.0"
+  flutter: ">=3.3.0"

--- a/ios/Classes/SwiftRemindersPlugin.swift
+++ b/ios/Classes/SwiftRemindersPlugin.swift
@@ -19,6 +19,9 @@ public class SwiftRemindersPlugin: NSObject, FlutterPlugin {
       case "hasAccess":
         result(self.reminders.hasAccess)
 
+      case "requestPermission":
+        result(self.reminders.requestPermission())
+
       case "getDefaultList":
         result(self.reminders.getDefaultList())
 
@@ -28,7 +31,7 @@ public class SwiftRemindersPlugin: NSObject, FlutterPlugin {
       case "getReminders":
         if let args = call.arguments as? [String: String?] {
           if let id = args["id"] {
-            self.reminders.getReminders(id) { (reminders) in 
+            self.reminders.getReminders(id) { (reminders) in
               result(reminders)
             }
           }
@@ -37,7 +40,7 @@ public class SwiftRemindersPlugin: NSObject, FlutterPlugin {
       case "saveReminder":
         if let args = call.arguments as? [String: Any] {
           if let reminder = args["reminder"] as? [String: Any] {
-            self.reminders.saveReminder(reminder) { (error) in 
+            self.reminders.saveReminder(reminder) { (error) in
               result(error)
             }
           }
@@ -46,7 +49,7 @@ public class SwiftRemindersPlugin: NSObject, FlutterPlugin {
     case "deleteReminder":
       if let args = call.arguments as? [String: String] {
         if let id = args["id"] {
-          self.reminders.deleteReminder(id) { (error) in 
+          self.reminders.deleteReminder(id) { (error) in
             result(error)
           }
         }

--- a/lib/reminders.dart
+++ b/lib/reminders.dart
@@ -14,6 +14,10 @@ class Reminders {
     return RemindersPlatform.instance.hasAccess();
   }
 
+  Future<bool> requestPermission() async {
+    return RemindersPlatform.instance.requestPermission();
+  }
+
   Future<RemList?> getDefaultList() async {
     return RemindersPlatform.instance.getDefaultList();
   }

--- a/lib/reminders_method_channel.dart
+++ b/lib/reminders_method_channel.dart
@@ -27,6 +27,12 @@ class MethodChannelReminders extends RemindersPlatform {
   }
 
   @override
+  Future<bool> requestPermission() async {
+    final access = await methodChannel.invokeMethod('requestPermission');
+    return access;
+  }
+
+  @override
   Future<RemList?> getDefaultList() async {
     final defaultList = await methodChannel.invokeMethod('getDefaultList');
     if (defaultList == null) return null;

--- a/lib/reminders_platform_interface.dart
+++ b/lib/reminders_platform_interface.dart
@@ -33,6 +33,10 @@ abstract class RemindersPlatform extends PlatformInterface {
     throw UnimplementedError('hasAccess() has not been implemented.');
   }
 
+  Future<bool> requestPermission() async {
+    throw UnimplementedError('requestPermission() has not been implemented.');
+  }
+
   Future<RemList?> getDefaultList() async {
     throw UnimplementedError('getDefaultList() has not been implemented.');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,18 +4,18 @@ version: 1.0.0
 homepage: https://github.com/berkobob/reminders
 
 environment:
-  sdk: '>=2.18.2 <3.0.0'
-  flutter: ">=2.5.0"
+  sdk: '>=2.18.2 <4.0.0'
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.0.2
+  plugin_platform_interface: ^2.1.4
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^2.0.1
 
 flutter:
   plugin:


### PR DESCRIPTION
Description:
This pull request addresses the open issue #123 and introduces a new function called `requestPermission()` to the Flutter Reminders plugin. The function provides developers with the ability to programmatically request permissions for accessing reminders instead of the current behavior, which automatically requests permissions upon initialization without any developer control.

The `requestPermission()` function returns a boolean value indicating whether the permission request was successful or not. This allows developers to handle the permission request flow in their application based on the returned value.

Changes Made:
- Added the `requestPermission()` function to the `Reminders` plugin.
- The function programmatically requests permission to access reminders.
- The function returns a boolean value indicating the success or failure of the permission request.
- Updated the documentation to include information about the new function and its usage.

Fixes:
- Resolves issue #1 , which addresses the lack of developer control over permission requests in the Reminders plugin.

Please review this pull request at your earliest convenience. Thank you!