### PR TITLE
Support iOS and iPad OS 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
+## 1.2.0 2023-09-24
+
+* Support for iOS & iPadOS 17's new permission handler
+* Breaking Changes: You need to add additional keys to your info.plist as seen in docs
 ## 1.1.0 2023-01-14
 
 * Add remove dueDate from reminder
 * Update example to test remove date
 * Fix 'all day' bug
-  
+
 ## 1.0.0 2022-11-05
 
 * Add saveReminder to create reminders and save changes
 * Full version
-  
+
 ## 0.1.0 2020-12-16
 
 * Update README with correct Key Value pair in info.plist

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ iOS 17 or ABOVE:
 >
 >    `<string>INSERT_REASON_HERE</string>`
 
-For now (iOS 17), you do not need the second entry but it is recommended you do so as 'NSRemindersUsageDescription' is deprecated and won't be supported in iOS 18+ which means your app will not be able to request permission!
+Warning: Although `NSRemindersUsageDescription` is forward compatible with iOS 17 , this does not appear to be the case with iPad OS 17 when compiling with Xcode 15. TLDR: just add both keys regardless!
 
 ## MacOS integration
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,19 @@ Future<String?> deleteReminder(String id) async`
 ## iOS integration
 
 Add the following key/value pair to your Info.plist
+
+iOS 17 or BELOW: 
 >
 >    `<key>NSRemindersUsageDescription</key>`
 >
 >    `<string>INSERT_REASON_HERE</string>`
 
+iOS 17 or ABOVE:
+>    `<key>NSRemindersFullAccessUsageDescription</key>`
+>
+>    `<string>INSERT_REASON_HERE</string>`
+
+For now (iOS 17), you do not need the second entry but it is recommended you do so as 'NSRemindersUsageDescription' is deprecated and won't be supported in iOS 18+ which means your app will not be able to request permission!
 
 ## MacOS integration
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,15 @@ This will prompt a system alert dialog with the text you provided from 'NSRemind
 
 `Future<bool> hasAccess()`
 
-Apple calendars has a default Reminders List it uses if no list is specified when creating a new reminder. The list can be determined:
+Apple Calendars has a default Reminders List it uses if no list is specified when creating a new reminder. The list ID can be determined:
+
+`Future<String?> getDefaultListId()`
+
+Apple Reminders support multiple lists of reminders. A complete list of lists can be determined:
 
 `Future<RemList?> getDefaultList()`
 
-Apple reminders supports multiple lists of reminders. A complete list of lists can be determined:
+Apple Reminders support multiple lists of reminders. A complete list of lists can be determined:
 
 `Future<List<RemList>> getAllLists()`
 
@@ -23,7 +27,7 @@ Get all the reminders in a List by passing the `RemList.id` to:
 
 `Future<List<Reminder>?> getReminders([String? id])`
 
-Attributes of a Reminder can be changed or a new Reminder can be created and then saved. Changes inlucde, but are not limited to, marking Reminders complete or not and setting due dates:
+Attributes of a Reminder can be changed or a new Reminder can be created and then saved. Changes induce, but are not limited to, marking Reminders complete or not and setting due dates:
 
 `Future<Reminder> saveReminder(Reminder reminder)`
 
@@ -34,7 +38,7 @@ Future<String?> deleteReminder(String id) async`
 
 Add the following key/value pair to your Info.plist
 
-iOS 17 or BELOW: 
+iOS 17 or BELOW:
 >
 >    `<key>NSRemindersUsageDescription</key>`
 >
@@ -58,4 +62,4 @@ Add the following to `macos/Runner/DebugProfile.entitlements` and 'macos/Runner/
 
 ### Android, Web, Windows & Linux integration
 
-As this plugin only supports Apple Reminders, there is no Android, Web, Windows or Linux integration.
+As this plugin only supports Apple Reminders, there is no Android, Web, Windows, or Linux integration.

--- a/common/Reminders.swift
+++ b/common/Reminders.swift
@@ -14,6 +14,13 @@ class Reminders {
         return nil
     }
 
+    func getDefaultListId() -> String? {
+        if let defaultList = defaultList {
+            return defaultList.calendarIdentifier
+        }
+        return nil
+    }
+
     func requestPermission() -> Bool {
         var granted = false
         let semaphore = DispatchSemaphore(value: 0)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,18 +37,18 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   fake_async:
     dependency: transitive
     description:
@@ -66,47 +66,39 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -127,17 +119,17 @@ packages:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      sha256: da3fdfeccc4d4ff2da8f8c556704c08f912542c5fb3cf2233ed75372384a034d
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.6"
   reminders:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.1.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -147,10 +139,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -187,10 +179,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   vector_math:
     dependency: transitive
     description:
@@ -199,6 +191,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.3.0"

--- a/ios/Classes/SwiftRemindersPlugin.swift
+++ b/ios/Classes/SwiftRemindersPlugin.swift
@@ -22,6 +22,9 @@ public class SwiftRemindersPlugin: NSObject, FlutterPlugin {
       case "requestPermission":
         result(self.reminders.requestPermission())
 
+      case "getDefaultListId":
+        result(self.reminders.getDefaultListId())
+
       case "getDefaultList":
         result(self.reminders.getDefaultList())
 

--- a/lib/reminders.dart
+++ b/lib/reminders.dart
@@ -18,6 +18,10 @@ class Reminders {
     return RemindersPlatform.instance.requestPermission();
   }
 
+  Future<String> getDefaultListId() async {
+    return RemindersPlatform.instance.getDefaultListId();
+  }
+
   Future<RemList?> getDefaultList() async {
     return RemindersPlatform.instance.getDefaultList();
   }

--- a/lib/reminders_method_channel.dart
+++ b/lib/reminders_method_channel.dart
@@ -33,6 +33,12 @@ class MethodChannelReminders extends RemindersPlatform {
   }
 
   @override
+  Future<String> getDefaultListId() async {
+    final access = await methodChannel.invokeMethod('getDefaultListId');
+    return access;
+  }
+
+  @override
   Future<RemList?> getDefaultList() async {
     final defaultList = await methodChannel.invokeMethod('getDefaultList');
     if (defaultList == null) return null;

--- a/lib/reminders_platform_interface.dart
+++ b/lib/reminders_platform_interface.dart
@@ -37,6 +37,10 @@ abstract class RemindersPlatform extends PlatformInterface {
     throw UnimplementedError('requestPermission() has not been implemented.');
   }
 
+  Future<String> getDefaultListId() async {
+    throw UnimplementedError('getDefaultListId() has not been implemented.');
+  }
+
   Future<RemList?> getDefaultList() async {
     throw UnimplementedError('getDefaultList() has not been implemented.');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reminders
 description: Read, Edit, Create and Delete Apple Reminders
-version: 1.0.0
+version: 1.2.0
 homepage: https://github.com/berkobob/reminders
 
 environment:


### PR DESCRIPTION
Solves issue #3 

iOS 17 & iPad OS 17 have a new permission API to allow for more granularised permissions. This pull aims to use the new APIs over the deprecated APIs when possible in a backward-compatible manner. 

Changed by developers are necessary! They will need to add a new key `NSRemindersFullAccessUsageDescription` to their info.plist !

It makes necessary changes to support iPad OS 17 as the previous request permission method is not forward-compatible for some weird reason when compiling with Xcode 15.